### PR TITLE
pwabuilder issue #1054

### DIFF
--- a/lib/platform-utils.js
+++ b/lib/platform-utils.js
@@ -15,7 +15,7 @@ function getSourcePathForIcon(manifest, size) {
 
     if (manifest.icons[squareValue] || manifest.icons[squareValue.toUpperCase()]) {
         var urlOrPath = manifest.icons[squareValue] || manifest.icons[squareValue.toUpperCase()];
-        return url.parse(urlOrPath).path;
+        return url.parse(urlOrPath).pathname;
     } else if (manifest.icons[size]) {
         return manifest.icons[size];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-macos",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwabuilder-macos",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Mac OS platform template",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://github.com/pwa-builder/PWABuilder/issues/1054

changing from path to pathname, the path includes the arguments and hash, which is tripping it up as the download converts the name to remove those

brings to parity with:
https://github.com/pwa-builder/pwabuilder-lib/blob/master/lib/platformBase.js#L290